### PR TITLE
Add CSV merge utility and tests

### DIFF
--- a/data/merge_results.py
+++ b/data/merge_results.py
@@ -1,0 +1,58 @@
+import csv
+import os
+from glob import glob
+from typing import Dict, List, Set
+
+DATA_DIR = os.path.dirname(__file__)
+OUTPUT_FILE = os.path.join(DATA_DIR, "combined_listings.csv")
+FIELDS = ["source", "title", "price", "mileage", "dealer", "location", "url"]
+
+
+def merge_csv_files(
+    input_dir: str = DATA_DIR,
+    pattern: str = "*_results.csv",
+    output_file: str = OUTPUT_FILE,
+) -> List[Dict[str, str]]:
+    """Merge CSV files in ``input_dir`` matching ``pattern``.
+
+    Rows are deduplicated by ``url`` and written to ``output_file``.
+    The merged rows are also returned for further processing.
+    """
+
+    paths = [
+        p
+        for p in glob(os.path.join(input_dir, pattern))
+        if os.path.isfile(p) and os.path.abspath(p) != os.path.abspath(output_file)
+    ]
+    paths.sort()
+
+    merged: List[Dict[str, str]] = []
+    seen_urls: Set[str] = set()
+
+    for path in paths:
+        with open(path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                url = row.get("url")
+                if url and url in seen_urls:
+                    continue
+                if url:
+                    seen_urls.add(url)
+                merged.append({field: row.get(field) for field in FIELDS})
+
+    if not merged:
+        print("No rows found to merge.")
+        return []
+
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
+    with open(output_file, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=FIELDS)
+        writer.writeheader()
+        writer.writerows(merged)
+
+    print(f"Merged {len(merged)} rows from {len(paths)} files into {output_file}")
+    return merged
+
+
+if __name__ == "__main__":
+    merge_csv_files()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for imports
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/tests/test_merge_results.py
+++ b/tests/test_merge_results.py
@@ -1,0 +1,70 @@
+import csv
+from pathlib import Path
+
+import data.merge_results as mr
+
+
+def _write_csv(path: Path, rows):
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=mr.FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_merge_csv_dedupes_by_url(tmp_path):
+    rows1 = [
+        {
+            "source": "cars.com",
+            "title": "Car A",
+            "price": "1000",
+            "mileage": "5000",
+            "dealer": "A",
+            "location": "X",
+            "url": "http://1",
+        },
+        {
+            "source": "cars.com",
+            "title": "Car B",
+            "price": "2000",
+            "mileage": "10000",
+            "dealer": "B",
+            "location": "Y",
+            "url": "http://2",
+        },
+    ]
+    rows2 = [
+        {
+            "source": "cargurus",
+            "title": "Car C",
+            "price": "3000",
+            "mileage": "15000",
+            "dealer": "C",
+            "location": "Z",
+            "url": "http://2",
+        },
+        {
+            "source": "craigslist",
+            "title": "Car D",
+            "price": "4000",
+            "mileage": "20000",
+            "dealer": "D",
+            "location": "W",
+            "url": "http://3",
+        },
+    ]
+
+    _write_csv(tmp_path / "a_results.csv", rows1)
+    _write_csv(tmp_path / "b_results.csv", rows2)
+
+    output_file = tmp_path / "combined.csv"
+    merged = mr.merge_csv_files(
+        input_dir=str(tmp_path), pattern="*_results.csv", output_file=str(output_file)
+    )
+
+    assert len(merged) == 3
+    assert output_file.exists()
+    with open(output_file, newline="", encoding="utf-8") as f:
+        out_rows = list(csv.DictReader(f))
+    assert len(out_rows) == 3
+    urls = [r["url"] for r in out_rows]
+    assert urls == ["http://1", "http://2", "http://3"]


### PR DESCRIPTION
## Summary
- implement `merge_csv_files` to combine per-source CSV files with URL-based deduplication
- add comprehensive tests for the merge utility
- ensure tests can import project modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf16bd71b08331b8ac9d9cd8023021