### PR TITLE
Add integration tests for scrapers and merge script

### DIFF
--- a/tests/test_merge_results.py
+++ b/tests/test_merge_results.py
@@ -68,3 +68,14 @@ def test_merge_csv_dedupes_by_url(tmp_path):
     assert len(out_rows) == 3
     urls = [r["url"] for r in out_rows]
     assert urls == ["http://1", "http://2", "http://3"]
+
+
+def test_merge_csv_no_files(tmp_path, capsys):
+    output_file = tmp_path / "combined.csv"
+    merged = mr.merge_csv_files(
+        input_dir=str(tmp_path), pattern="*_results.csv", output_file=str(output_file)
+    )
+    assert merged == []
+    assert not output_file.exists()
+    captured = capsys.readouterr()
+    assert "No rows found to merge." in captured.out

--- a/tests/test_scrape_cargurus.py
+++ b/tests/test_scrape_cargurus.py
@@ -62,6 +62,18 @@ class CarGurusScraperTests(unittest.TestCase):
             rows = cg.scrape()
         self.assertEqual(rows, [])
 
+    @patch("requests.Session.get")
+    def test_scrape_returns_rows(self, mock_get):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.text = SAMPLE_HTML
+        mock_get.return_value = resp
+        with patch.object(cg, "make_session") as ms, patch.object(cg, "MAX_PAGES", 1), patch.object(cg, "PAGE_DELAY_RANGE", (0, 0)):
+            ms.return_value = cg.requests.Session()
+            rows = cg.scrape()
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["source"], "cargurus")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_scrape_carscom.py
+++ b/tests/test_scrape_carscom.py
@@ -67,5 +67,17 @@ class CarsComScraperTests(unittest.TestCase):
             rows = sc.scrape()
         self.assertEqual(rows, [])
 
+    @patch("requests.Session.get")
+    def test_scrape_returns_rows(self, mock_get):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.text = SAMPLE_HTML
+        mock_get.return_value = resp
+        with patch.object(sc, 'make_session') as ms, patch.object(sc, 'MAX_PAGES', 1), patch.object(sc, 'PAGE_DELAY_RANGE', (0, 0)):
+            ms.return_value = sc.requests.Session()
+            rows = sc.scrape()
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]['source'], 'cars.com')
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_scrape_craigslist.py
+++ b/tests/test_scrape_craigslist.py
@@ -58,6 +58,18 @@ class CraigslistScraperTests(unittest.TestCase):
             rows = sc.scrape()
         self.assertEqual(rows, [])
 
+    @patch("requests.Session.get")
+    def test_scrape_returns_rows(self, mock_get):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.text = SAMPLE_HTML
+        mock_get.return_value = resp
+        with patch.object(sc, 'make_session') as ms, patch.object(sc, 'MAX_PAGES', 1), patch.object(sc, 'PAGE_DELAY_RANGE', (0, 0)):
+            ms.return_value = sc.requests.Session()
+            rows = sc.scrape()
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]['source'], 'craigslist')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add tests exercising successful scrape flows for cargurus, cars.com, and craigslist scrapers
- cover merge_csv_files when no input files are present

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf191e067c83318ef3c15d752a1d9c