### PR TITLE
Deduplicate nested vehicle cards in cars.com parser

### DIFF
--- a/scrape_carscom.py
+++ b/scrape_carscom.py
@@ -74,6 +74,7 @@ def parse_listings(html: str) -> List[Dict]:
     soup = BeautifulSoup(html, "lxml")
     cards = soup.select(".vehicle-card, article.vehicle-card")
     results: List[Dict] = []
+    seen_urls = set()
 
     for card in cards:
         # URL
@@ -109,6 +110,16 @@ def parse_listings(html: str) -> List[Dict]:
 
         if not url and not title:
             continue
+
+        # The markup sometimes nests an <article> with class
+        # ``vehicle-card`` inside another element with the same class,
+        # which would cause duplicate rows.  Use the listing URL as a
+        # simple deduplication key to avoid returning the same car
+        # multiple times.
+        if url and url in seen_urls:
+            continue
+        if url:
+            seen_urls.add(url)
 
         results.append(
             {

--- a/tests/test_scrape_carscom.py
+++ b/tests/test_scrape_carscom.py
@@ -28,6 +28,20 @@ SAMPLE_HTML = """
 </html>
 """
 
+DUPLICATE_HTML = """
+<html>
+  <body>
+    <div class="vehicle-card">
+      <article class="vehicle-card">
+        <a class="vehicle-card-link" href="/vehicledetail/abcd1234">2012 Toyota Camry</a>
+        <div class="primary-price">$8,999</div>
+        <div class="mileage">123,456 mi.</div>
+      </article>
+    </div>
+  </body>
+</html>
+"""
+
 class CarsComScraperTests(unittest.TestCase):
     def test_parse_listings_extracts_fields(self):
         rows = sc.parse_listings(SAMPLE_HTML)
@@ -54,6 +68,10 @@ class CarsComScraperTests(unittest.TestCase):
         titles = [r["title"] for r in filtered]
         self.assertTrue(any("Toyota Camry" in t for t in titles))
         self.assertFalse(any("2002" in t for t in titles))
+
+    def test_parse_listings_avoids_duplicate_cards(self):
+        rows = sc.parse_listings(DUPLICATE_HTML)
+        self.assertEqual(len(rows), 1)
 
     @patch("requests.Session.get")
     def test_scrape_handles_http_errors(self, mock_get):


### PR DESCRIPTION
## Summary
- Avoid duplicate records by tracking seen vehicle URLs when parsing cars.com pages
- Add regression test verifying nested vehicle cards are not double-counted

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf1a3ecddc8331b73cbb5aebe8924d