### PR TITLE
Add fixture-based cars.com tests with live marker

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,25 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 # Ensure project root is on sys.path for imports
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--live",
+        action="store_true",
+        default=False,
+        help="run tests that hit the live network",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "live: mark test as requiring network access")
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    if "live" in item.keywords and not item.config.getoption("--live"):
+        pytest.skip("need --live option to run")

--- a/tests/fixtures/carscom_page1.html
+++ b/tests/fixtures/carscom_page1.html
@@ -1,0 +1,18 @@
+<html>
+  <body>
+    <div class="vehicle-card">
+      <a class="vehicle-card-link" href="/vehicledetail/abc123/">2010 Honda Accord LX</a>
+      <div class="primary-price">$4,500</div>
+      <div class="mileage">123,456 mi.</div>
+      <div class="dealer-name">Best Dealer</div>
+      <div class="dealer-name__location">Philadelphia, PA</div>
+    </div>
+    <div class="vehicle-card">
+      <a class="vehicle-card-link" href="/vehicledetail/def456/">2009 Toyota Camry LE</a>
+      <div class="primary-price">$3,999</div>
+      <div class="mileage">150,000 mi.</div>
+      <div class="dealer-name">Budget Cars</div>
+      <div class="dealer-name__location">Camden, NJ</div>
+    </div>
+  </body>
+</html>

--- a/tests/test_scrape_carscom.py
+++ b/tests/test_scrape_carscom.py
@@ -1,98 +1,43 @@
-import os
-import sys
-import unittest
+import pathlib
 from unittest.mock import patch
 
-import requests
+import pytest
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import scrape_carscom as sc
 
+FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "carscom_page1.html"
 
-class CarsComScraperLiveTests(unittest.TestCase):
-    """Tests that exercise the cars.com scraper against the live site.
 
-    These tests make real HTTP requests. If the site is unreachable, the
-    tests are skipped so the suite can still run in restricted environments.
+def test_parse_listings_from_fixture():
+    html = FIXTURE.read_text()
+    rows = sc.parse_listings(html)
+    assert rows
+    first = rows[0]
+    assert first["source"] == "cars.com"
+    assert first["title"]
+    assert first["url"].startswith("https://www.cars.com/")
 
-    When TEST_ALLOW_SELENIUM_FALLBACK=1 is set, the test will fall back to
-    using Selenium to fetch the page HTML if the initial requests-based
-    fetch fails or returns an unexpected status code. This enables running
-    the tests locally in environments where cars.com requires JS/cookies.
-    """
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.session = sc.make_session()
-        url = sc.build_search_url(1)
-        # First attempt: plain requests
+def test_filter_by_config_applies_limits():
+    html = FIXTURE.read_text()
+    rows = sc.parse_listings(html)
+    filtered = sc.filter_by_config(rows)
+    for row in filtered:
+        price = row.get("price")
+        mileage = row.get("mileage")
+        if price is not None:
+            assert price <= int(sc.config.PRICE_MAX)
+        if mileage is not None:
+            assert mileage <= int(sc.config.MILEAGE_MAX)
+
+
+@pytest.mark.live
+def test_scrape_live():
+    with patch.object(sc, "MAX_PAGES", 1), patch.object(sc, "PAGE_DELAY_RANGE", (0, 0)), patch.object(sc, "FETCH_MODE", "requests"):
         try:
-            resp = cls.session.get(url, timeout=sc.REQUEST_TIMEOUT)
-            ok = resp.status_code == 200 and bool(resp.text)
-        except requests.RequestException:  # pragma: no cover - network
-            ok = False
-            resp = None
-
-        # Optional fallback: Selenium (env-gated)
-        if not ok and os.getenv("TEST_ALLOW_SELENIUM_FALLBACK") in ("1", "true", "True"):
-            driver = None
-            try:
-                driver = sc.make_driver()
-                html = sc.fetch_html_selenium(driver, url)
-                if html:
-                    cls.html = html
-                    cls.rows = sc.parse_listings(cls.html)
-                    return
-            except Exception:
-                pass
-            finally:
-                if driver:
-                    try:
-                        driver.quit()
-                    except Exception:
-                        pass
-
-        # If still not OK, skip the test class entirely
-        if not ok:
-            raise unittest.SkipTest(
-                f"cars.com request failed or returned unexpected response"
-            )
-        # Success with requests
-        cls.html = resp.text  # type: ignore[union-attr]
-        cls.rows = sc.parse_listings(cls.html)
-
-    def test_parse_listings_live(self) -> None:
-        self.assertGreater(len(self.rows), 0)
-        first = self.rows[0]
-        self.assertEqual(first["source"], "cars.com")
-        self.assertTrue(first["title"])
-        self.assertTrue(first["url"].startswith("https://www.cars.com/"))
-
-    def test_filter_by_config_applies_limits(self) -> None:
-        filtered = sc.filter_by_config(self.rows)
-        for row in filtered:
-            price = row.get("price")
-            mileage = row.get("mileage")
-            if price is not None:
-                self.assertLessEqual(price, int(sc.config.PRICE_MAX))
-            if mileage is not None:
-                self.assertLessEqual(mileage, int(sc.config.MILEAGE_MAX))
-
-    def test_scrape_live(self) -> None:
-        # Decide fetch mode: keep requests for CI; allow selenium locally
-        fetch_mode = (
-            "selenium" if os.getenv("TEST_ALLOW_SELENIUM_FALLBACK") in ("1", "true", "True") else "requests"
-        )
-        with patch.object(sc, "MAX_PAGES", 1), \
-             patch.object(sc, "PAGE_DELAY_RANGE", (0, 0)), \
-             patch.object(sc, "FETCH_MODE", fetch_mode):
             rows = sc.scrape()
-        if not rows:
-            self.skipTest("No rows returned from live scrape")
-        self.assertGreater(len(rows), 0)
-        self.assertEqual(rows[0]["source"], "cars.com")
-
-
-if __name__ == "__main__":  # pragma: no cover - manual execution
-    unittest.main()
-
+        except Exception as exc:  # pragma: no cover - network issues
+            pytest.skip(f"Live scrape failed: {exc}")
+    if not rows:
+        pytest.skip("No rows returned from live scrape")
+    assert rows[0]["source"] == "cars.com"


### PR DESCRIPTION
## Summary
- Add cars.com HTML fixture for deterministic unit tests
- Replace unittest class with pytest tests using fixture and `@pytest.mark.live`
- Introduce `--live` option in conftest to gate network tests

## Testing
- `pytest -q`
- `pytest --live -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf6f2ee9bc8331a5e735cf65116128