### PR TITLE
test: load CarGurus HTML from fixture

### DIFF
--- a/tests/fixtures/cargurus_page1.html
+++ b/tests/fixtures/cargurus_page1.html
@@ -1,0 +1,18 @@
+<html>
+  <body>
+    <div class="cg-dealFinderResult-wrap">
+      <a class="listing-link" href="/Cars/SomeListingId1">2012 Toyota Camry</a>
+      <span class="listing-price">$8,999</span>
+      <span class="listing-mileage">123,456 mi</span>
+      <span class="dealer-name">Best Dealer</span>
+      <span class="listing-location">Philadelphia, PA</span>
+    </div>
+    <div class="cg-dealFinderResult-wrap">
+      <a class="listing-link" href="/Cars/SomeListingId2">2002 Honda Civic</a>
+      <span class="listing-price">$3,500</span>
+      <span class="listing-mileage">200,001 mi</span>
+      <span class="dealer-name">Good Cars</span>
+      <span class="listing-location">Philly, PA</span>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- store sample CarGurus listings HTML in `tests/fixtures/cargurus_page1.html`
- load fixture in `test_scrape_cargurus` instead of inline `SAMPLE_HTML`

## Testing
- `pytest`
- `pytest --live -q` *(fails: unrecognized arguments: --live)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6f3c82888331ab15847223b20329