### PR TITLE
Use Craigslist fixture and mark network tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,29 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 # Ensure project root is on sys.path for imports
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--live",
+        action="store_true",
+        default=False,
+        help="Run tests marked as requiring network access",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "live: tests that access live network resources")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--live"):
+        return
+    skip_live = pytest.mark.skip(reason="need --live option to run")
+    for item in items:
+        if "live" in item.keywords:
+            item.add_marker(skip_live)

--- a/tests/fixtures/craigslist_page1.html
+++ b/tests/fixtures/craigslist_page1.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <ul class="rows">
+      <li class="result-row">
+        <a class="result-title" href="https://philadelphia.craigslist.org/cto/d/car-2012-toyota-camry/123.html">2012 Toyota Camry</a>
+        <span class="result-price">$3,500</span>
+        <span class="result-hood">(Philadelphia)</span>
+      </li>
+      <li class="result-row">
+        <a class="result-title" href="https://philadelphia.craigslist.org/cto/d/car-2002-honda-civic/456.html">2002 Honda Civic</a>
+        <span class="result-price">$5,000</span>
+        <span class="result-hood">(Philly)</span>
+      </li>
+    </ul>
+  </body>
+</html>

--- a/tests/test_scrape_carscom.py
+++ b/tests/test_scrape_carscom.py
@@ -4,11 +4,13 @@ import unittest
 from unittest.mock import patch
 
 import requests
+import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import scrape_carscom as sc
 
 
+@pytest.mark.live
 class CarsComScraperLiveTests(unittest.TestCase):
     """Tests that exercise the cars.com scraper against the live site.
 


### PR DESCRIPTION
## Summary
- store Craigslist results as fixture and load it in tests
- mark live network tests and add pytest `--live` option
- ensure live tests skipped unless requested

## Testing
- `pytest`
- `pytest --live -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf6f3d6b648331acd391ef5399d8ca