### PR TITLE
docs: add verbose pytest command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ uv run python data/merge_results.py
 
 ## Run tests
 
-Use uv to execute the test suite:
+Use uv to execute the test suite with verbose output:
 
 ```bash
-uv run pytest
+uv run pytest -v
 ```
 
 Target: `data/combined_listings.csv`


### PR DESCRIPTION
## Summary
- document running the test suite in verbose mode using `uv run pytest -v`

## Testing
- `uv run pytest -v` *(fails: NameError: name 'unittest' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7b2dd45c8331b3e4550a99c49273