### PR TITLE
Handle Craigslist JSON search results

### DIFF
--- a/tests/fixtures/craigslist_page1.html
+++ b/tests/fixtures/craigslist_page1.html
@@ -1,16 +1,23 @@
 <html>
   <body>
-    <ul>
-      <li class="result-row">
-        <a class="result-title" href="/cto/12345.html">2009 Toyota Camry</a>
-        <span class="result-price">$3,500</span>
-        <span class="result-hood">(Philadelphia)</span>
-      </li>
-      <li class="result-row">
-        <a class="result-title" href="/cto/67890.html">2002 Honda Civic</a>
-        <span class="result-price">$2,000</span>
-        <span class="result-hood">(New York)</span>
-      </li>
-    </ul>
+    <script id="ld_searchpage_results" type="application/ld+json">
+{
+  "about": [
+    {
+      "name": "2009 Toyota Camry",
+      "price": 3500,
+      "url": "/cto/12345.html",
+      "areaServed": {"name": "Philadelphia"}
+    },
+    {
+      "name": "2002 Honda Civic",
+      "price": 2000,
+      "url": "/cto/67890.html",
+      "areaServed": {"name": "New York"}
+    }
+  ]
+}
+    </script>
   </body>
 </html>
+


### PR DESCRIPTION
## Summary
- parse structured JSON in `ld_searchpage_results` script for Craigslist listings
- fall back to legacy HTML selectors if JSON is missing
- update test fixture to reflect JSON-based search results

## Testing
- `pytest tests/test_scrape_craigslist.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68bf8057220483318134c5ed4defa0d9