### PR TITLE
Add Selenium fallback flag for cars.com scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Run individually; each writes a CSV to `data/`.
 ```bash
 # Cars.com (static; fastest to validate pipeline)
 uv run python scrape_carscom.py
+# enable Selenium fallback if needed
+USE_SELENIUM=1 uv run python scrape_carscom.py
 
 # Craigslist (private sellers)
 uv run python scrape_craigslist.py

--- a/tests/test_scrape_carscom.py
+++ b/tests/test_scrape_carscom.py
@@ -41,7 +41,7 @@ class CarsComScraperLiveTests(unittest.TestCase):
 @pytest.mark.live
 def test_scrape_live():
     with patch.object(sc, "MAX_PAGES", 1), patch.object(sc, "PAGE_DELAY_RANGE", (0, 0)), patch.object(
-        sc, "FETCH_MODE", "requests"
+        sc, "USE_SELENIUM", False
     ):
         try:
             rows = sc.scrape()
@@ -50,3 +50,40 @@ def test_scrape_live():
     if not rows:
         pytest.skip("No rows returned from live scrape")
     assert rows[0]["source"] == "cars.com"
+
+
+def test_scrape_requests_only():
+    dummy_session = object()
+    with patch.object(sc, "make_session", return_value=dummy_session), patch.object(
+        sc, "fetch_html_requests", return_value="<html></html>"
+    ) as fr, patch.object(sc, "parse_listings", return_value=[{"source": "cars.com"}]), patch.object(
+        sc, "fetch_html_selenium"
+    ) as fs, patch.object(sc, "MAX_PAGES", 1), patch.object(sc, "PAGE_DELAY_RANGE", (0, 0)), patch.object(
+        sc, "USE_SELENIUM", False
+    ):
+        rows = sc.scrape()
+    assert fr.called
+    fs.assert_not_called()
+    assert rows
+
+
+def test_scrape_selenium_fallback():
+    class DummyDriver:
+        def quit(self):
+            pass
+
+    dummy_session = object()
+    dummy_driver = DummyDriver()
+
+    with patch.object(sc, "make_session", return_value=dummy_session), patch.object(
+        sc, "fetch_html_requests", return_value="<html></html>"
+    ), patch.object(
+        sc, "parse_listings", side_effect=[[], [{"source": "cars.com"}]]
+    ), patch.object(
+        sc, "fetch_html_selenium", return_value="<html></html>"
+    ) as fs, patch.object(sc, "make_driver", return_value=dummy_driver), patch.object(
+        sc, "MAX_PAGES", 1
+    ), patch.object(sc, "PAGE_DELAY_RANGE", (0, 0)), patch.object(sc, "USE_SELENIUM", True):
+        rows = sc.scrape()
+    assert fs.called
+    assert rows


### PR DESCRIPTION
## Summary
- add USE_SELENIUM env var and remove FETCH_MODE handling
- retry with Selenium only if requests-based fetch returns no listings
- update tests and docs for USE_SELENIUM paths

## Testing
- ⚠️ `pytest -q` (missing dependency: requests)
- ✅ `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf84a2791c8331af4e62d6d5b430c4