### PR TITLE
Use attribute selectors for CarGurus scraping

### DIFF
--- a/scrape_cargurus.py
+++ b/scrape_cargurus.py
@@ -163,11 +163,11 @@ def parse_listings(html: str) -> List[Dict]:
 
     # Fallback to parsing visible HTML cards
     cards = soup.select(
-        ".cg-dealFinderResult-wrap, div[data-listingid], div.listing-item"
+        "[data-test='inventory-listing'], [data-cg-ft='inventory-listing'], div[data-listingid]"
     )
 
     for card in cards:
-        link = card.select_one("a[href]")
+        link = card.select_one("a[data-test='listing-link'], a[itemprop='url'], a[href]")
         href_val = link.get("href") if link else None
         if isinstance(href_val, list):
             href_val = href_val[0] if href_val else None
@@ -177,26 +177,26 @@ def parse_listings(html: str) -> List[Dict]:
         title = link.get_text(strip=True) if link else None
 
         price_el = card.select_one(
-            ".listing-price, .cg-dealFinderPrice, [data-test='listing-price']"
+            "[data-test='listing-price'], [itemprop='price'], [data-cg-ft='listing-price']"
         )
         price_text = price_el.get_text(strip=True) if price_el else None
         price = clean_number(price_text)
 
         mileage_el = card.select_one(
-            ".listing-mileage, .cg-listingDetail-byline, [data-test='mileage']"
+            "[data-test='mileage'], [data-test='listing-mileage'], [itemprop='mileage']"
         )
         mileage_text = mileage_el.get_text(strip=True) if mileage_el else None
         mileage = clean_number(mileage_text)
 
         dealer_el = card.select_one(
-            ".dealer-name, .cg-dealerName, [data-test='dealer-name']"
+            "[data-test='dealer-name'], [itemprop='seller'], [data-cg-ft='dealer-name']"
         )
-        dealer = dealer_el.get_text(" ", strip=True) if dealer_el else None
+        dealer = dealer_el.get_text(strip=True) if dealer_el else None
 
         location_el = card.select_one(
-            ".listing-location, .cg-dealerAddress, [data-test='dealer-address']"
+            "[data-test='dealer-address'], [data-test='listing-location'], [itemprop='address']"
         )
-        location = location_el.get_text(" ", strip=True) if location_el else None
+        location = location_el.get_text(strip=True) if location_el else None
 
         if not url and not title:
             continue

--- a/tests/cassettes/test_live_cargurus/cargurus_one_page.yaml
+++ b/tests/cassettes/test_live_cargurus/cargurus_one_page.yaml
@@ -15,19 +15,19 @@ interactions:
       string: |
         <html>
           <body>
-            <div class="cg-dealFinderResult-wrap">
-              <a class="listing-link" href="/Cars/SomeListingId1">2012 Toyota Camry</a>
-              <span class="listing-price">$8,999</span>
-              <span class="listing-mileage">123,456 mi</span>
-              <span class="dealer-name">Best Dealer</span>
-              <span class="listing-location">Philadelphia, PA</span>
+            <div data-test="inventory-listing">
+              <a data-test="listing-link" href="/Cars/SomeListingId1">2012 Toyota Camry</a>
+              <span data-test="listing-price">$8,999</span>
+              <span data-test="mileage">123,456 mi</span>
+              <span data-test="dealer-name">Best Dealer</span>
+              <span data-test="dealer-address">Philadelphia, PA</span>
             </div>
-            <div class="cg-dealFinderResult-wrap">
-              <a class="listing-link" href="/Cars/SomeListingId2">2002 Honda Civic</a>
-              <span class="listing-price">$3,500</span>
-              <span class="listing-mileage">200,001 mi</span>
-              <span class="dealer-name">Good Cars</span>
-              <span class="listing-location">Philly, PA</span>
+            <div data-test="inventory-listing">
+              <a data-test="listing-link" href="/Cars/SomeListingId2">2002 Honda Civic</a>
+              <span data-test="listing-price">$3,500</span>
+              <span data-test="mileage">200,001 mi</span>
+              <span data-test="dealer-name">Good Cars</span>
+              <span data-test="dealer-address">Philly, PA</span>
             </div>
           </body>
         </html>

--- a/tests/fixtures/cargurus_page1.html
+++ b/tests/fixtures/cargurus_page1.html
@@ -1,18 +1,18 @@
 <html>
   <body>
-    <div class="cg-dealFinderResult-wrap">
-      <a href="/Cars/2009-Toyota-Camry">2009 Toyota Camry</a>
-      <div class="cg-dealFinderPrice">$8,999</div>
-      <div class="cg-listingDetail-byline">123,456 mi</div>
-      <div class="cg-dealerName">Best Dealer</div>
-      <div class="cg-dealerAddress">Philadelphia, PA</div>
+    <div data-test="inventory-listing">
+      <a data-test="listing-link" href="/Cars/2009-Toyota-Camry">2009 Toyota Camry</a>
+      <div data-test="listing-price">$8,999</div>
+      <div data-test="mileage">123,456 mi</div>
+      <div data-test="dealer-name">Best Dealer</div>
+      <div data-test="dealer-address">Philadelphia, PA</div>
     </div>
-    <div class="cg-dealFinderResult-wrap">
-      <a href="/Cars/2002-Honda-Civic">2002 Honda Civic</a>
-      <div class="cg-dealFinderPrice">$4,000</div>
-      <div class="cg-listingDetail-byline">200,000 mi</div>
-      <div class="cg-dealerName">Another Dealer</div>
-      <div class="cg-dealerAddress">New York, NY</div>
+    <div data-test="inventory-listing">
+      <a data-test="listing-link" href="/Cars/2002-Honda-Civic">2002 Honda Civic</a>
+      <div data-test="listing-price">$4,000</div>
+      <div data-test="mileage">200,000 mi</div>
+      <div data-test="dealer-name">Another Dealer</div>
+      <div data-test="dealer-address">New York, NY</div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Switch CarGurus listing parser to stable attribute selectors (data-test/itemprop)
- Guard element lookups with `get_text(strip=True)` and None checks
- Refresh fixture and cassette HTML for attribute-based selectors

## Testing
- `pytest tests/test_scrape_cargurus.py -q`
- `pytest tests/test_live_cargurus.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf849f61788331a9832608c4445c02