### PR TITLE
Add polite scraping delays via throttling utility

### DIFF
--- a/scrape_cargurus.py
+++ b/scrape_cargurus.py
@@ -1,15 +1,15 @@
 import csv
 import json
 import os
-import random
-import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlencode, urljoin
 
 import requests
 from bs4 import BeautifulSoup
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
+
+from utils.throttle import polite_sleep
 
 import config
 
@@ -30,7 +30,8 @@ HEADERS = {
 OUTPUT_DIR = "data"
 OUTPUT_FILE = os.path.join(OUTPUT_DIR, "cargurus_results.csv")
 MAX_PAGES = int(os.getenv("CARGURUS_MAX_PAGES", "10"))
-PAGE_DELAY_RANGE = (2.0, 6.0)
+# Polite delay range between page requests (seconds) for cargurus.com
+PAGE_DELAY_RANGE: Tuple[float, float] = (2.0, 6.0)
 REQUEST_TIMEOUT = int(os.getenv("CARGURUS_TIMEOUT", "45"))
 
 
@@ -273,7 +274,7 @@ def scrape() -> List[Dict]:
         print(f"[cargurus] Parsed {len(page_rows)} listings from page {page}.")
         all_rows.extend(page_rows)
 
-        time.sleep(random.uniform(*PAGE_DELAY_RANGE))
+        polite_sleep(PAGE_DELAY_RANGE)
 
     return all_rows
 

--- a/scrape_carscom.py
+++ b/scrape_carscom.py
@@ -1,8 +1,6 @@
 import csv
 import os
-import random
-import time
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlencode, urljoin
 
 import requests
@@ -17,6 +15,8 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait  # fixed import
 from selenium.webdriver.support import expected_conditions as EC
 from webdriver_manager.chrome import ChromeDriverManager
+
+from utils.throttle import polite_sleep
 
 import config
 
@@ -42,7 +42,8 @@ HEADERS = {
 OUTPUT_DIR = "data"
 OUTPUT_FILE = os.path.join(OUTPUT_DIR, "carscom_results.csv")
 MAX_PAGES = int(os.getenv("CARS_MAX_PAGES", "10"))  # safety cap
-PAGE_DELAY_RANGE = (2.0, 6.0)
+# Polite delay range between page requests (seconds) for cars.com
+PAGE_DELAY_RANGE: Tuple[float, float] = (2.0, 6.0)
 REQUEST_TIMEOUT = int(os.getenv("CARS_TIMEOUT", "45"))
 FETCH_MODE = os.getenv("CARS_FETCH_MODE", "auto").lower()  # auto | requests | selenium
 SELENIUM_WAIT = int(os.getenv("CARS_SELENIUM_WAIT", "12"))
@@ -280,7 +281,7 @@ def scrape() -> List[Dict]:
         all_rows.extend(page_rows)
 
         # Polite delay between pages
-        time.sleep(random.uniform(*PAGE_DELAY_RANGE))
+        polite_sleep(PAGE_DELAY_RANGE)
 
     if driver:
         try:

--- a/scrape_craigslist.py
+++ b/scrape_craigslist.py
@@ -1,15 +1,15 @@
 import csv
 import json
 import os
-import random
-import time
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlencode, urljoin
 
 import requests
 from bs4 import BeautifulSoup
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
+
+from utils.throttle import polite_sleep
 
 import config
 
@@ -28,7 +28,8 @@ HEADERS = {
 OUTPUT_DIR = "data"
 OUTPUT_FILE = os.path.join(OUTPUT_DIR, "craigslist_results.csv")
 MAX_PAGES = int(os.getenv("CRAIG_MAX_PAGES", "10"))
-PAGE_DELAY_RANGE = (3.0, 7.0)
+# Polite delay range between page requests (seconds) for Craigslist
+PAGE_DELAY_RANGE: Tuple[float, float] = (3.0, 7.0)
 REQUEST_TIMEOUT = int(os.getenv("CRAIG_TIMEOUT", "45"))
 
 
@@ -205,7 +206,7 @@ def scrape() -> List[Dict]:
         print(f"[craigslist] Parsed {len(page_rows)} listings from page {page}.")
         all_rows.extend(page_rows)
 
-        time.sleep(random.uniform(*PAGE_DELAY_RANGE))
+        polite_sleep(PAGE_DELAY_RANGE)
 
     return all_rows
 

--- a/utils/throttle.py
+++ b/utils/throttle.py
@@ -1,0 +1,26 @@
+"""Utilities for throttling scraper requests."""
+
+from __future__ import annotations
+
+import random
+import time
+from typing import Tuple
+
+
+def polite_sleep(delay_range: Tuple[float, float]) -> float:
+    """Sleep for a random interval within ``delay_range``.
+
+    Parameters
+    ----------
+    delay_range:
+        Two-tuple of ``(min_seconds, max_seconds)`` representing the
+        inclusive bounds for a random sleep duration.
+
+    Returns
+    -------
+    float
+        The actual number of seconds slept.
+    """
+    delay = random.uniform(*delay_range)
+    time.sleep(delay)
+    return delay


### PR DESCRIPTION
## Summary
- add `polite_sleep` helper for randomized delays
- switch scrapers to use `polite_sleep` and document per-site delay ranges

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf84996edc8331b1ccb88e6b61507b