### PR TITLE
Add canonical URL and first_seen checks to scraper tests

### DIFF
--- a/data/merge_results.py
+++ b/data/merge_results.py
@@ -1,7 +1,7 @@
 import csv
 import os
 from glob import glob
-from typing import Dict, List, Set
+from typing import Dict, List
 
 DATA_DIR = os.path.dirname(__file__)
 OUTPUT_FILE = os.path.join(DATA_DIR, "combined_listings.csv")
@@ -35,21 +35,28 @@ def merge_csv_files(
     ]
     paths.sort()
 
-    merged: List[Dict[str, str]] = []
-    seen_urls: Set[str] = set()
+    merged: Dict[str, Dict[str, str]] = {}
 
     for path in paths:
         with open(path, newline="", encoding="utf-8") as f:
             reader = csv.DictReader(f)
             for row in reader:
                 url = row.get("url")
-                if url and url in seen_urls:
+                if not url:
                     continue
-                if url:
-                    seen_urls.add(url)
-                merged.append({field: row.get(field) for field in FIELDS})
+                data = {field: row.get(field) for field in FIELDS}
+                if url in merged:
+                    existing = merged[url]
+                    new_fs = data.get("first_seen") or ""
+                    old_fs = existing.get("first_seen") or ""
+                    if new_fs and (not old_fs or new_fs < old_fs):
+                        merged[url] = data
+                else:
+                    merged[url] = data
 
-    if not merged:
+    merged_rows = list(merged.values())
+
+    if not merged_rows:
         print("No rows found to merge.")
         return []
 
@@ -57,10 +64,10 @@ def merge_csv_files(
     with open(output_file, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(f, fieldnames=FIELDS)
         writer.writeheader()
-        writer.writerows(merged)
+        writer.writerows(merged_rows)
 
-    print(f"Merged {len(merged)} rows from {len(paths)} files into {output_file}")
-    return merged
+    print(f"Merged {len(merged_rows)} rows from {len(paths)} files into {output_file}")
+    return merged_rows
 
 
 if __name__ == "__main__":

--- a/tests/test_merge_results.py
+++ b/tests/test_merge_results.py
@@ -31,7 +31,7 @@ def test_merge_csv_dedupes_by_url(tmp_path):
             "dealer": "B",
             "location": "Y",
             "url": "http://2",
-            "first_seen": "2024-01-01T00:00:00",
+            "first_seen": "2024-01-02T00:00:00",
         },
     ]
     rows2 = [
@@ -43,7 +43,7 @@ def test_merge_csv_dedupes_by_url(tmp_path):
             "dealer": "C",
             "location": "Z",
             "url": "http://2",
-            "first_seen": "2024-01-02T00:00:00",
+            "first_seen": "2024-01-01T00:00:00",
         },
         {
             "source": "craigslist",
@@ -53,7 +53,7 @@ def test_merge_csv_dedupes_by_url(tmp_path):
             "dealer": "D",
             "location": "W",
             "url": "http://3",
-            "first_seen": "2024-01-02T00:00:00",
+            "first_seen": "2024-01-03T00:00:00",
         },
     ]
 
@@ -66,12 +66,16 @@ def test_merge_csv_dedupes_by_url(tmp_path):
     )
 
     assert len(merged) == 3
+    merged_map = {r["url"]: r["first_seen"] for r in merged}
+    assert merged_map["http://2"] == "2024-01-01T00:00:00"
     assert output_file.exists()
     with open(output_file, newline="", encoding="utf-8") as f:
         out_rows = list(csv.DictReader(f))
     assert len(out_rows) == 3
     urls = [r["url"] for r in out_rows]
     assert urls == ["http://1", "http://2", "http://3"]
+    first_seen = {r["url"]: r["first_seen"] for r in out_rows}
+    assert first_seen["http://2"] == "2024-01-01T00:00:00"
 
 
 def test_merge_csv_no_files(tmp_path, capsys):

--- a/tests/test_scrape_cargurus.py
+++ b/tests/test_scrape_cargurus.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+from utils.url import canonical_url
+
 import scrape_cargurus as cg
 
 
@@ -27,6 +29,7 @@ class CarGurusScraperTests(unittest.TestCase):
         self.assertIn("Philadelphia", first["location"])
         self.assertNotIn("?", first["url"])
         self.assertNotIn("#", first["url"])
+        self.assertEqual(first["url"], canonical_url(first["url"]))
         datetime.fromisoformat(first["first_seen"])
 
     def test_filter_by_config_applies_limits(self):
@@ -64,6 +67,7 @@ class CarGurusScraperTests(unittest.TestCase):
         self.assertEqual(rows[0]["source"], "cargurus")
         self.assertNotIn("?", rows[0]["url"])
         self.assertNotIn("#", rows[0]["url"])
+        self.assertEqual(rows[0]["url"], canonical_url(rows[0]["url"]))
         datetime.fromisoformat(rows[0]["first_seen"])
 
 

--- a/tests/test_scrape_carscom.py
+++ b/tests/test_scrape_carscom.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 import pytest
 import requests
 
+from utils.url import canonical_url
+
 pytestmark = pytest.mark.live
 
 import scrape_carscom as sc
@@ -25,7 +27,7 @@ class CarsComScraperLiveTests(unittest.TestCase):
         assert first["source"] == "cars.com"
         assert first["title"]
         assert first["url"].startswith("https://www.cars.com/")
-        assert "?" not in first["url"] and "#" not in first["url"]
+        assert first["url"] == canonical_url(first["url"])
         datetime.fromisoformat(first["first_seen"])
 
     def test_filter_by_config_applies_limits(self):
@@ -53,6 +55,8 @@ def test_scrape_live():
     if not rows:
         pytest.skip("No rows returned from live scrape")
     assert rows[0]["source"] == "cars.com"
+    assert rows[0]["url"] == canonical_url(rows[0]["url"])
+    datetime.fromisoformat(rows[0]["first_seen"])
 
 
 def test_scrape_requests_only():

--- a/tests/test_scrape_craigslist.py
+++ b/tests/test_scrape_craigslist.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 os.environ.setdefault("CRAIGS_DOMAIN", "philadelphia")
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from utils.url import canonical_url
 import scrape_craigslist as sc
 
 FIXTURE_PATH = Path(__file__).parent / "fixtures" / "craigslist_page1.html"
@@ -26,6 +27,7 @@ class CraigslistScraperTests(unittest.TestCase):
         self.assertEqual(first["location"], "Philadelphia")
         self.assertNotIn("?", first["url"])
         self.assertNotIn("#", first["url"])
+        self.assertEqual(first["url"], canonical_url(first["url"]))
         datetime.fromisoformat(first["first_seen"])
 
     def test_filter_by_config_applies_limits(self):
@@ -62,6 +64,7 @@ class CraigslistScraperTests(unittest.TestCase):
         self.assertEqual(rows[0]['source'], 'craigslist')
         self.assertNotIn("?", rows[0]['url'])
         self.assertNotIn("#", rows[0]['url'])
+        self.assertEqual(rows[0]['url'], canonical_url(rows[0]['url']))
         datetime.fromisoformat(rows[0]['first_seen'])
 
     @patch("requests.Session.get")


### PR DESCRIPTION
## Summary
- Ensure scraper tests validate canonicalized URLs and track `first_seen` timestamps
- Verify merged CSVs include `first_seen` and retain the earliest value per URL
- Deduplicate merged results by URL while keeping the earliest `first_seen`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf873ee8c48331b5fe17d5c0d88924